### PR TITLE
Incorrect name for coverage lib in requirements files.

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,5 @@
 # Local development dependencies go here
 -r _base.txt
-coverage.py==3.6
+coverage==3.6
 django-discover-runner==0.2.2
 django-debug-toolbar==0.9.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
 # Test dependencies go here.
 -r _base.txt
-coverage.py==3.6
+coverage==3.6
 django-discover-runner==0.2.2


### PR DESCRIPTION
I've changed the library name from 'coverage.py' to 'coverage' to reflect the name on the PyPi.
