### PR TITLE
fix license to have this year's date

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 201w Audrey Roy, Daniel Greenfeld, and contributors.
+Copyright (c) 2013 Audrey Roy, Daniel Greenfeld, and contributors.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
took a look at this and noticed that the license said `201w` which I assume was suppose to be `2013` or `2012` depending on when it was originally made. 
