### PR TITLE
Fix relative import of base settings

### DIFF
--- a/project_name/project_name/settings/local.py
+++ b/project_name/project_name/settings/local.py
@@ -3,7 +3,7 @@
 
 from os.path import join, normpath
 
-from base import *
+from .base import *
 
 
 ########## DEBUG CONFIGURATION

--- a/project_name/project_name/settings/local.py
+++ b/project_name/project_name/settings/local.py
@@ -1,5 +1,6 @@
 """Development settings and globals."""
 
+from __future__ import absolute_import
 
 from os.path import join, normpath
 

--- a/project_name/project_name/settings/production.py
+++ b/project_name/project_name/settings/production.py
@@ -3,7 +3,7 @@
 
 from os import environ
 
-from base import *
+from .base import *
 
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.

--- a/project_name/project_name/settings/production.py
+++ b/project_name/project_name/settings/production.py
@@ -1,5 +1,6 @@
 """Production settings and globals."""
 
+from __future__ import absolute_import
 
 from os import environ
 

--- a/project_name/project_name/settings/test.py
+++ b/project_name/project_name/settings/test.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from .base import *
 
 ########## TEST SETTINGS

--- a/project_name/project_name/settings/test.py
+++ b/project_name/project_name/settings/test.py
@@ -1,4 +1,4 @@
-from base import *
+from .base import *
 
 ########## TEST SETTINGS
 TEST_RUNNER = 'discover_runner.DiscoverRunner'


### PR DESCRIPTION
I just tried out your template project for one of my own and got an import error for the `local.py`:

```
ImportError: Could not import settings 'synpho.settings.local' (Is it on sys.path?): No module named base
```

Looking at the files importing `base` it seems like the imports are supposed to be relative but are defined as absolute. Your code snippet in the book confirms that that's the intended way. I fixed it in the three settings files. I am a bit confused though since it seems that others have used the project successfully. So if I am missing something really obvious, just ignore this :smile:

Oh, and thanks for a great book. It's a great and educating read :thumbsup: 
