### PR TITLE
Minor fixes to include changes from Django 1.5

### DIFF
--- a/project_name/project_name/settings/production.py
+++ b/project_name/project_name/settings/production.py
@@ -61,3 +61,10 @@ CACHES = {}
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = get_env_setting('SECRET_KEY')
 ########## END SECRET CONFIGURATION
+
+
+########## SITE CONFIGURATION
+# Hosts/domain names that are valid for this site
+# See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = []
+########## END SITE CONFIGURATION

--- a/project_name/project_name/settings/production.py
+++ b/project_name/project_name/settings/production.py
@@ -18,7 +18,6 @@ def get_env_setting(setting):
 		error_msg = "Set the %s env variable" % setting
 		raise ImproperlyConfigured(error_msg)
 		
-INSTALLED_APPS += ('gunicorn',)
 
 ########## EMAIL CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#email-backend


### PR DESCRIPTION
1. Removing Gunicorn's Django integration as [recommended](https://docs.djangoproject.com/en/dev/howto/deployment/wsgi/gunicorn/) in Django docs:
   
   > If you are using Django 1.4 or newer, it’s highly recommended to simply run your application with the WSGI interface using the `gunicorn` command as described above.
2. Including `ALLOWED_HOSTS` in production settings.
