### PR TITLE
ALLOWED_HOSTS required when DEBUG is set to False in Django 1.5.

### DIFF
--- a/project_name/project_name/settings/production.py
+++ b/project_name/project_name/settings/production.py
@@ -20,6 +20,11 @@ def get_env_setting(setting):
 
 INSTALLED_APPS += ('gunicorn',)
 
+########## HOST CONFIGURATION
+# See: https://docs.djangoproject.com/en/1.5/releases/1.5/#allowed-hosts-required-in-production
+ALLOWED_HOSTS = []
+########## END HOST CONFIGURATION
+
 ########## EMAIL CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
@@ -45,7 +50,6 @@ EMAIL_USE_TLS = True
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#server-email
 SERVER_EMAIL = EMAIL_HOST_USER
 ########## END EMAIL CONFIGURATION
-
 
 ########## DATABASE CONFIGURATION
 DATABASES = {}


### PR DESCRIPTION
Settings file validates, but server returns 500 error page — no logging is specified — making this variable's absence difficult to debug.
