### PR TITLE
Fix location of WSGI application

### DIFF
--- a/project_name/project_name/settings/base.py
+++ b/project_name/project_name/settings/base.py
@@ -240,5 +240,5 @@ LOGGING = {
 
 ########## WSGI CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#wsgi-application
-WSGI_APPLICATION = 'wsgi.application'
+WSGI_APPLICATION = '%s.wsgi.application' % SITE_NAME
 ########## END WSGI CONFIGURATION


### PR DESCRIPTION
`wsgi.py` is located in `project_name/project_name` folder, so the name should be `project_name.wsgi.application`. Otherwise Django cannot find the application.
