### PR TITLE
Added XframeOptionsMiddleware to default template

### DIFF
--- a/project_name/project_name/settings/base.py
+++ b/project_name/project_name/settings/base.py
@@ -163,6 +163,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 ########## END MIDDLEWARE CONFIGURATION
 


### PR DESCRIPTION
This adds django.middleware.clickjacking.XFrameOptionsMiddleware to the MIDDLEWARE_CLASSES in the default template.

I've tested this on Django 1.5.1, by creating a fresh project from the template, starting up runserver, and verifying the presence of the header.
