### PR TITLE
Remove THIRD_PARTY_APPS and define configuration per third-party app

### DIFF
--- a/project_name/project_name/settings/base.py
+++ b/project_name/project_name/settings/base.py
@@ -192,17 +192,12 @@ DJANGO_APPS = (
     # 'django.contrib.admindocs',
 )
 
-THIRD_PARTY_APPS = (
-    # Database migration helpers:
-    'south',
-)
-
 # Apps specific for this project go here.
 LOCAL_APPS = (
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
-INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
+INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS
 ########## END APP CONFIGURATION
 
 
@@ -243,3 +238,12 @@ LOGGING = {
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#wsgi-application
 WSGI_APPLICATION = 'wsgi.application'
 ########## END WSGI CONFIGURATION
+
+
+########## SOUTH CONFIGURATION
+# See: http://south.readthedocs.org/en/latest/installation.html#configuring-your-django-installation
+INSTALLED_APPS += (
+    # Database migration helpers:
+    'south',
+)
+########## END SOUTH CONFIGURATION


### PR DESCRIPTION
Its practical and tidy to group configurations per app.

A lot of third party apps require a significant amount of configuration,
it's convenient to be able to look at the configuration
of an app in previous project you used the app in. The existence of
THIRD_PARTY_APPS then violates DRY.

There are THIRD_PARTY apps like South where an entry in INSTALLED_APPS
is the only configuration. I believe it is more important to group
the configurations per app together at the cost of having a few extra
commented lines than not grouping third party configurations at all. 
