### PR TITLE
Add support to .gitignore to also ignore Emacs, Mac system files, and Windows system files which often will appear from mounting *nix shares.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,6 @@
 # Packaging files:
 *.egg*
 
-# Editor temp files:
-*.swp
-*~
-
 # Sphinx docs:
 build
 
@@ -16,3 +12,27 @@ build
 
 # Logs:
 *.log
+
+# Eclipse
+.project
+
+# Linux Editors
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+.elc
+auto-save-list
+tramp
+.\#*
+*.swp
+*.swo
+
+# Mac
+.DS_Store
+._*
+
+# Windows
+Thumbs.db
+Desktop.ini
+


### PR DESCRIPTION
We are a team where people use a variety of IDEs, despite most of us being command line bashers. This would add support to keep IDEs from mucking repositories up with editor backup files, project files, thumbnail files, and more.

We have run into this issue a few times, and I've changed the .gitignore to match what has served us best in keeping the repository clean. Best regards.
