### PR TITLE
Upgrade django-debug-toolbar to v1.0.

### DIFF
--- a/project_name/project_name/settings/local.py
+++ b/project_name/project_name/settings/local.py
@@ -48,22 +48,17 @@ CACHES = {
 
 
 ########## TOOLBAR CONFIGURATION
-# See: https://github.com/django-debug-toolbar/django-debug-toolbar#installation
+# See: http://django-debug-toolbar.readthedocs.org/en/latest/installation.html#explicit-setup
 INSTALLED_APPS += (
     'debug_toolbar',
 )
 
-# See: https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-INTERNAL_IPS = ('127.0.0.1',)
-
-# See: https://github.com/django-debug-toolbar/django-debug-toolbar#installation
 MIDDLEWARE_CLASSES += (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 
-# See: https://github.com/django-debug-toolbar/django-debug-toolbar#installation
-DEBUG_TOOLBAR_CONFIG = {
-    'INTERCEPT_REDIRECTS': False,
-    'SHOW_TEMPLATE_CONTEXT': True,
-}
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
+
+# http://django-debug-toolbar.readthedocs.org/en/latest/installation.html
+INTERNAL_IPS = ('127.0.0.1',)
 ########## END TOOLBAR CONFIGURATION

--- a/project_name/project_name/urls.py
+++ b/project_name/project_name/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import patterns, include, url
 from django.views.generic import TemplateView
+from django.conf import settings
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
@@ -18,3 +19,9 @@ urlpatterns = patterns('',
     # Uncomment the next line to enable the admin:
     url(r'^admin/', include(admin.site.urls)),
 )
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += patterns('',
+                            url(r'^__debug__/', include(debug_toolbar.urls)),
+                            )

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,5 +2,5 @@
 -r base.txt
 coverage==3.6
 django-discover-runner==0.4
-django-debug-toolbar==0.9.4
+django-debug-toolbar==1.0.1
 Sphinx==1.2b1


### PR DESCRIPTION
As per title - this marks a break in how the debug-toolbar is installed.
There are 2 ways now to install this app; I've gone for the 'explicit' setup, as the 'quick setup' comes with several caveats and edge cases where it doesn't work (and I have already experienced this!).
At the same time I've changed the links in the comments: instead of pointing to the Github page, I've redirected them to readthedocs. I trust that this is ok?
