### PR TITLE
Remove explicit usage of django-discover-runner.

### DIFF
--- a/project_name/project_name/settings/test.py
+++ b/project_name/project_name/settings/test.py
@@ -2,11 +2,6 @@ from __future__ import absolute_import
 
 from .base import *
 
-########## TEST SETTINGS
-TEST_RUNNER = 'discover_runner.DiscoverRunner'
-TEST_DISCOVER_TOP_LEVEL = SITE_ROOT
-TEST_DISCOVER_ROOT = SITE_ROOT
-TEST_DISCOVER_PATTERN = "test_*.py"
 ########## IN-MEMORY TEST DATABASE
 DATABASES = {
     "default": {

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,6 +1,5 @@
 # Local development dependencies go here
 -r base.txt
 coverage==3.6
-django-discover-runner==0.4
 django-debug-toolbar==1.0.1
 Sphinx==1.2.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
 # Test dependencies go here.
 -r base.txt
 coverage==3.6
-django-discover-runner==0.4


### PR DESCRIPTION
Since upgrading the required Django version to 1.6, django.test.runner.DiscoverRunner is now the default TEST_RUNNER.
