### PR TITLE
Speed up tests that require user login

### DIFF
--- a/project_name/project_name/settings/test.py
+++ b/project_name/project_name/settings/test.py
@@ -16,3 +16,7 @@ DATABASES = {
         "PORT": "",
     },
 }
+
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+)


### PR DESCRIPTION
The md5 password hasher is considerably faster compared to the default one. Since login security isn't concern while unit testing, then it's a no-brainer.
