### PR TITLE
Update pip requirements

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,4 @@
 # Local development dependencies go here
--r base.txt
-coverage==3.7.1
+-r test.txt
 django-debug-toolbar==1.2.1
 Sphinx==1.2.2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,5 @@
 # Local development dependencies go here
 -r base.txt
-coverage==3.6
-django-debug-toolbar==1.0.1
-Sphinx==1.2.1
+coverage==3.7.1
+django-debug-toolbar==1.2.1
+Sphinx==1.2.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,4 +2,4 @@
 #	production that isn't in development.
 -r base.txt
 
-gunicorn==0.17.4
+gunicorn==18.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,3 @@
 # Test dependencies go here.
 -r base.txt
-coverage==3.6
+coverage==3.7.1


### PR DESCRIPTION
Simply updating the package versions.

This should also fix #88 and remove the redundant `coverage` package listed in both `local.txt` and `test.txt`.
