### PR TITLE
Move templatetag for loading static files in base.html

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -29,3 +29,4 @@ Daniel Chimeno / @chimeno
 Eduardo Matos / @eduardo-matos
 Noel Martin Llevares / @dashmug
 Adam Duren / @adamduren
+Patrick Beeson / @patrickbeeson

--- a/project_name/templates/base.html
+++ b/project_name/templates/base.html
@@ -1,5 +1,5 @@
-{% templatetag openblock %} load staticfiles {% templatetag closeblock %}
 <!DOCTYPE html>
+{% templatetag openblock %} load staticfiles {% templatetag closeblock %}
 <html lang="en">
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Move templatetag for loading static files in base.html template to below doctype to avoid throwing IE into quirks mode.
